### PR TITLE
paragraf4.json Oprava překlepu v otázce 37.

### DIFF
--- a/data/paragraf4.json
+++ b/data/paragraf4.json
@@ -615,7 +615,7 @@
        "question":"Elektrická zařízení třídy ochrany II musí mít připojovací vidlici:",
        "answers":[
           {
-             "text":"S ochranného vodiče",
+             "text":"S ochranným vodičem",
              "right":false
           },
           {


### PR DESCRIPTION
Oprava překlepu v špatné odpovědi na otázku 37 (Elektrická zařízení třídy ochrany II musí mít připojovací vidlici:) z "S ochranného vodiče" na "S ochranným vodičem".